### PR TITLE
fix typos and error of path in miracl.get

### DIFF
--- a/thirdparty/linux/miracl.get
+++ b/thirdparty/linux/miracl.get
@@ -1,6 +1,9 @@
 cat "downloading Miracl"
 echo "building Mircal"
+export ROOT=$(pwd)
+echo $ROOT
 cd miracl/miracl/source/
 bash linux64
-cd miracl/miracl_ostm/source/
-bash linux64
+cd $ROOT
+cd miracl/miracl_osmt/source/
+bash linux64_cpp


### PR DESCRIPTION
miracl.get has some errors, and build of bOPRFmain.exe will report error with libmiracl.a.
