### PR TITLE
fix(miracl): correct wrong path and compilation error

### DIFF
--- a/thirdparty/linux/miracl.get
+++ b/thirdparty/linux/miracl.get
@@ -2,5 +2,5 @@ cat "downloading Miracl"
 echo "building Mircal"
 cd miracl/miracl/source/
 bash linux64
-cd miracl/miracl_ostm/source/
-bash linux64
+cd ../../../miracl/miracl_osmt/source/
+bash linux64_cpp

--- a/thirdparty/linux/miracl/miracl_osmt/source/zzn.cpp
+++ b/thirdparty/linux/miracl/miracl_osmt/source/zzn.cpp
@@ -163,18 +163,17 @@ ZZn pow(int n,ZZn *a,Big *b)
 
 #endif
 
+ZZn luc( const ZZn& b1, const Big& b2, ZZn *b3=NULL)
+{ZZn z; if (b3!=NULL) nres_lucas(b1.fn,b2.getbig(),b3->fn,z.fn); 
+        else          nres_lucas(b1.fn,b2.getbig(),z.fn,z.fn); 
+ return z;}
+
 // fast ZZn2 powering using lucas functions..
 
 ZZn powl(const ZZn& x,const Big& k)
 {
     return luc(2*x,k)/2;
 }
-
-ZZn luc( const ZZn& b1, const Big& b2, ZZn *b3)
-{ZZn z; if (b3!=NULL) nres_lucas(b1.fn,b2.getbig(),b3->fn,z.fn); 
-        else          nres_lucas(b1.fn,b2.getbig(),z.fn,z.fn); 
- return z;}
-
 
 ZZn sqrt(const ZZn& b)
 {ZZn z; nres_sqroot(b.fn,z.fn); return z;}

--- a/thirdparty/linux/miracl/miracl_osmt/source/zzn.h
+++ b/thirdparty/linux/miracl/miracl_osmt/source/zzn.h
@@ -183,7 +183,7 @@ public:
     friend ZZn getB(void);        // get B parameter of elliptic curve
 
     friend ZZn  sqrt(const ZZn&); // only works if modulus is prime
-    friend ZZn  luc( const ZZn&, const Big&, ZZn* b3=NULL);
+    friend ZZn  luc( const ZZn&, const Big&, ZZn* b3);
 
     big getzzn(void) const;
 


### PR DESCRIPTION
- correct wrong path in miracle.get
- fix some compilation errors of function luc in zzn.h and zzn.cpp

The patch fixes some compilation errors in building libmiracl.a, tests on Ubuntu 20.04.3 x86_64 with g++ 9.4.0 and sed 4.2.2-8:
- `zzn.h:186:17: error: friend declaration of ‘ZZn luc(const ZZn&, const Big&, ZZn*)’ specifies default arguments and isn’t a definition`, the standard (§8.3.6-4) says that "If a friend declaration specifies a default argument expression, that declaration shall be a definition and shall be the only declaration of the function or function template in the translation unit".
- `zzn.cpp:170:21: error: no matching function for call to ‘luc(ZZn, const Big&)’`, order of luc and powl need to exchange.